### PR TITLE
removed a tag for empty error that has no link

### DIFF
--- a/src/main/assets/scss/main.scss
+++ b/src/main/assets/scss/main.scss
@@ -6,3 +6,8 @@
 textarea {
   overflow: hidden;
 }
+
+span.error-message {
+  color: #d4351c;
+  font-weight: 700;
+}

--- a/src/main/views/forms/base.njk
+++ b/src/main/views/forms/base.njk
@@ -42,7 +42,11 @@
               <ul class="govuk-list govuk-error-summary__list">
                 {% for key, error in validationErrors %}
                 <li>
-                  <a id="error-id-{{key}}" href="#flagComment-{{key}}">{% if _t(error) %}{{ _t(error) }}{% else %}error{% endif %}</a>
+                  {% if key === parent.id %}
+                    <span class="error-message" id="error-id-{{key}}">{% if _t(error) %}{{ _t(error) }}{% else %}error{% endif %}</span>
+                  {% else %}
+                    <a id="error-id-{{key}}" href="#flagComment-{{key}}">{% if _t(error) %}{{ _t(error) }}{% else %}error{% endif %}</a>
+                  {% endif %}
                 </li>
                 {% endfor %}
               </ul>


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/CUIRA-214

### Change description ###

if the error message does not link to a field it will be shown as a span instead of an a tag

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
