### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -32,13 +32,13 @@ resource "azurerm_key_vault_secret" "AZURE_APPINSGHTS_KEY" {
   key_vault_id = module.key-vault.key_vault_id
 }
 
-resource "azurerm_application_insights" "appinsights" {
-  name                = "${var.product}-${var.env}"
-  location            = var.location
-  resource_group_name = azurerm_resource_group.rg.name
-  application_type    = "web"
-  tags                = var.common_tags
-}
+# resource "azurerm_application_insights" "appinsights" {
+#   name                = "${var.product}-${var.env}"
+#   location            = var.location
+#   resource_group_name = azurerm_resource_group.rg.name
+#   application_type    = "web"
+#   tags                = var.common_tags
+# }
 
 //data "azurerm_subnet" "core_infra_redis_subnet" {
 //  name                 = "core-infra-subnet-1-${var.env}"


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15909


### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in 
February 2024.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
