### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -28,17 +28,27 @@ module "key-vault" {
 
 resource "azurerm_key_vault_secret" "AZURE_APPINSGHTS_KEY" {
   name         = "AppInsightsInstrumentationKey"
-  value        = azurerm_application_insights.appinsights.instrumentation_key
+  value        = module.application_insights.instrumentation_key
   key_vault_id = module.key-vault.key_vault_id
 }
 
-# resource "azurerm_application_insights" "appinsights" {
-#   name                = "${var.product}-${var.env}"
-#   location            = var.location
-#   resource_group_name = azurerm_resource_group.rg.name
-#   application_type    = "web"
-#   tags                = var.common_tags
-# }
+
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+
+  env     = var.env
+  product = var.product
+  name    = var.product
+
+  resource_group_name = azurerm_resource_group.rg.name
+
+  common_tags = var.common_tags
+}
+
+moved {
+  from = azurerm_application_insights.appinsights
+  to   = module.application_insights.azurerm_application_insights.this
+}
 
 //data "azurerm_subnet" "core_infra_redis_subnet" {
 //  name                 = "core-infra-subnet-1-${var.env}"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -32,13 +32,13 @@ resource "azurerm_key_vault_secret" "AZURE_APPINSGHTS_KEY" {
   key_vault_id = module.key-vault.key_vault_id
 }
 
-resource "azurerm_application_insights" "appinsights" {
-  name                = "${var.product}-${var.env}"
-  location            = var.location
-  resource_group_name = azurerm_resource_group.rg.name
-  application_type    = "web"
-  tags                = var.common_tags
-}
+# resource "azurerm_application_insights" "appinsights" {
+#   name                = "${var.product}-${var.env}"
+#   location            = var.location
+#   resource_group_name = azurerm_resource_group.rg.name
+#   application_type    = "web"
+#   tags                = var.common_tags
+# }
 
 //data "azurerm_subnet" "core_infra_redis_subnet" {
 //  name                 = "core-infra-subnet-1-${var.env}"


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.