### PR TITLE
CUIRA-287 remove /health/ endpoint logging

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -2,7 +2,7 @@
   "useCSRFProtection": true,
   "appInsights": {
     "connectionString": false,
-    "samplingPercentage": 33
+    "samplingPercentage": 100
   },
   "demo": {
     "enabled": true

--- a/src/main/modules/appinsights/index.ts
+++ b/src/main/modules/appinsights/index.ts
@@ -1,3 +1,4 @@
+import { Envelope } from 'applicationinsights/out/Declarations/Contracts';
 import config from 'config';
 
 const appInsights = require('applicationinsights');
@@ -14,6 +15,9 @@ export class AppInsights {
 
       appInsights.defaultClient.config.samplingPercentage = config.get('appInsights.samplingPercentage');
       appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] = 'cui-ra';
+      appInsights.defaultClient.addTelemetryProcessor(
+        (envelope: Envelope) => !envelope.data['baseData'].url?.includes('/health/')
+      );
       appInsights.defaultClient.trackTrace({
         message: 'App insights activated',
       });


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/CUIRA-287

### Change description ###

Do not log /health/ endpoint calls which makes up 99% of our app insights logs