### PR TITLE
added fullfunctional script back in for nightly

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:routes": "jest --detectOpenHandles --forceExit -c jest.routes.config.js",
     "test:a11y": "jest --detectOpenHandles --forceExit -c jest.a11y.config.js --maxWorkers 1",
     "test:smoke": "NODE_TLS_REJECT_UNAUTHORIZED=1 jest -c jest.smoke.config.js",
+    "test:fullfunctional": "NODE_TLS_REJECT_UNAUTHORIZED=1 codeceptjs run --config ./src/test/functional/codecept.conf.js --steps",
     "test:functional": "NODE_TLS_REJECT_UNAUTHORIZED=1 codeceptjs run --config ./src/test/functional/codecept.conf.js --steps",
     "test:functional:new-journey-e2e": "NODE_TLS_REJECT_UNAUTHORIZED=1 codeceptjs run --config ./src/test/functional/codecept.conf.js --steps --grep @new-journey-e2e",
     "test:functional:existing-journey-e2e": "NODE_TLS_REJECT_UNAUTHORIZED=1 codeceptjs run --config ./src/test/functional/codecept.conf.js --steps --grep @existing-journey-e2e",


### PR DESCRIPTION
### Change description ###

nightly build is expecting the script fullfunctional to exist in the package.json this was originally there but was renamed to functional.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
