### PR TITLE
Enable CVE dashboard ingestion

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure")
+@Library("Infrastructure@cve-dashboard")
 
 def type = "nodejs"
 def product = "cui"
@@ -14,6 +14,7 @@ withEnv([
 ]) {
 
     withPipeline(type, product, component) {
+        enableCveDashboardIngestion()
 
         before('build') {
             sh '''


### PR DESCRIPTION
## Summary
- use the CVE Dashboard branch of the shared Jenkins Infrastructure library
- enable CVE Dashboard ingestion using the default production branch behaviour

## Context
This follows the tested wiring from hmcts/ccd-admin-web#883, but uses the production enableCveDashboardIngestion() call without explicit branch overrides.

## Testing
- Not run; Jenkins pipeline configuration change only